### PR TITLE
Removed getStudentNotInAnyClass route from TeachersRoute

### DIFF
--- a/backend/routes/teacherRoutes.js
+++ b/backend/routes/teacherRoutes.js
@@ -17,7 +17,6 @@ router.get('/get-classes', getClassesForTeacher);
 router.get('/get-teacher-by-class', getTeachersInClass);
 router.get('/get-student-by-class', getStudentsInClass);
 router.get('/get-student-not-in-class', getStudentsNotInAClass);
-router.get('/get-student-not-in-any-class', getStudentsNotInAnyClass);
 
 module.exports = router;
 


### PR DESCRIPTION
Issue #10 
As per requirement, the old route from teacherRoutes has been removed. 